### PR TITLE
list-authorized-keys: Don't use nul separators

### DIFF
--- a/container/list-authorized-keys
+++ b/container/list-authorized-keys
@@ -4,5 +4,5 @@ DIR=/var/run/authorized_keys.d
 
 if [ -d "$DIR" ]
 then
-  find $DIR -type f -print0 | xargs -0 cat | sort | uniq
+  find $DIR -type f | xargs cat | sort | uniq
 fi


### PR DESCRIPTION
This caused two `authorized_keys` files to be concatenated without a newline character separating them, so the last line in the 1st file and the first key in the 2nd file got printed on one line.